### PR TITLE
Widen return types for greater compatibility

### DIFF
--- a/Entity/Traits/TimestampsTrait.php
+++ b/Entity/Traits/TimestampsTrait.php
@@ -11,14 +11,14 @@ use Doctrine\ORM\Mapping as ORM;
 trait TimestampsTrait
 {
     /**
-     * @var \DateTimeImmutable
+     * @var \DateTimeInterface
      * @ORM\Column(name="time_created", type="datetime_immutable")
      */
     private $timeCreated;
 
 
     /**
-     * @var \DateTimeImmutable|null
+     * @var \DateTimeInterface|null
      * @ORM\Column(name="time_modified", type="datetime_immutable", nullable=true)
      */
     private $timeModified;
@@ -26,7 +26,7 @@ trait TimestampsTrait
 
 
     /**
-     * @return \DateTimeImmutable
+     * @return \DateTimeInterface
      */
     public function getTimeCreated () : \DateTimeInterface
     {
@@ -36,7 +36,7 @@ trait TimestampsTrait
 
 
     /**
-     * @return \DateTimeImmutable|null
+     * @return \DateTimeInterface|null
      */
     public function getTimeModified () : ?\DateTimeInterface
     {
@@ -58,7 +58,7 @@ trait TimestampsTrait
     /**
      * Returns the most recent modification time
      *
-     * @return \DateTimeImmutable
+     * @return \DateTimeInterface
      */
     public function getLastModificationTime () : \DateTimeInterface
     {

--- a/Entity/Traits/TimestampsTrait.php
+++ b/Entity/Traits/TimestampsTrait.php
@@ -28,7 +28,7 @@ trait TimestampsTrait
     /**
      * @return \DateTimeImmutable
      */
-    public function getTimeCreated () : \DateTimeImmutable
+    public function getTimeCreated () : \DateTimeInterface
     {
         return $this->timeCreated;
     }
@@ -38,7 +38,7 @@ trait TimestampsTrait
     /**
      * @return \DateTimeImmutable|null
      */
-    public function getTimeModified () : ?\DateTimeImmutable
+    public function getTimeModified () : ?\DateTimeInterface
     {
         return $this->timeModified;
     }
@@ -60,7 +60,7 @@ trait TimestampsTrait
      *
      * @return \DateTimeImmutable
      */
-    public function getLastModificationTime () : \DateTimeImmutable
+    public function getLastModificationTime () : \DateTimeInterface
     {
         return $this->getTimeModified() ?? $this->getTimeCreated();
     }


### PR DESCRIPTION
This is especially useful for cross-lib-interoperability, e.g. with our `SearchBundle` which has the `SearchableEntityInterface` with their `getLastModificationTime` method but with the return type being `\DateTimeInterface`.