### PR TITLE
Allow null in the IdTrait

### DIFF
--- a/Entity/Traits/IdTrait.php
+++ b/Entity/Traits/IdTrait.php
@@ -15,14 +15,14 @@ trait IdTrait
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(name="id", type="integer")
      *
-     * @var int
+     * @var int|null
      */
     private $id;
 
 
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getId ()
     {


### PR DESCRIPTION
It is possible that the id of an object like the user object is null so we have to allow null as well.