### PR TITLE
Add `appendToKey()` twig function

### DIFF
--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -4,3 +4,4 @@ services:
         autowire: true
 
     Becklyn\RadBundle\Form\FormErrorMapper: ~
+    Becklyn\RadBundle\Twig\RadTwigExtension: ~

--- a/Tests/Twig/RadTwigExtensionTest.php
+++ b/Tests/Twig/RadTwigExtensionTest.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\RadBundle\tests\Twig;
+
+use Becklyn\RadBundle\Twig\RadTwigExtension;
+use PHPUnit\Framework\TestCase;
+
+class RadTwigExtensionTest extends TestCase
+{
+    public function testAppendToKey ()
+    {
+        $extension = new RadTwigExtension();
+        $array = [
+            "existing" => "abc",
+        ];
+
+        self::assertSame("abc 123", $extension->appendToKey($array, "existing", "123")["existing"]);
+        self::assertSame("123", $extension->appendToKey($array, "missing", "123")["missing"]);
+    }
+}

--- a/Twig/RadTwigExtension.php
+++ b/Twig/RadTwigExtension.php
@@ -25,7 +25,7 @@ class RadTwigExtension extends AbstractExtension
     /**
      * @return array|\Twig_Filter[]
      */
-    public function getFilters ()
+    public function getFilters () : array
     {
         return [
             new TwigFilter("appendToKey", [$this, "appendToKey"]),

--- a/Twig/RadTwigExtension.php
+++ b/Twig/RadTwigExtension.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\RadBundle\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class RadTwigExtension extends AbstractExtension
+{
+    /**
+     * @param array  $map
+     * @param string $key
+     * @param string $append
+     *
+     * @return array
+     */
+    public function appendToKey (array $map, string $key, string $append) : array
+    {
+        $value = $map[$key] ?? "";
+        $map[$key] = \trim("{$value} {$append}");
+        return $map;
+    }
+
+
+    /**
+     * @return array|\Twig_Filter[]
+     */
+    public function getFilters ()
+    {
+        return [
+            new TwigFilter("appendToKey", [$this, "appendToKey"]),
+        ];
+    }
+}


### PR DESCRIPTION
The new function appends a string to a key in an array.
Commonly used in twig, for example when rendering forms.