### PR TITLE
Add form option: `attr_row`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ php:
 before_install:
     - composer require php-coveralls/php-coveralls --no-interaction --no-progress
     - composer global require localheinz/composer-normalize --no-interaction --prefer-dist --no-progress
-    - composer self-update --stable --no-interaction --no-progress
 
 install:
     - composer install --no-interaction --prefer-dist --no-progress

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ php:
     - 7.3
 
 before_install:
-    - composer require php-coveralls/php-coveralls --no-interaction --no-progress
-    - composer global require localheinz/composer-normalize --no-interaction --prefer-dist --no-progress
+    - composer require php-coveralls/php-coveralls --prefer-dist --no-interaction --no-progress
+    - composer global require localheinz/composer-normalize --prefer-dist --no-interaction --no-progress
 
 install:
-    - composer install --no-interaction --prefer-dist --no-progress
+    - composer install --prefer-dist --no-interaction --no-progress
 
 script:
     - mkdir -p build/logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: php
 sudo: false
 
+cache:
+    directories:
+        - $HOME/.composer/cache/files
+
 git:
     depth: 1
 
@@ -9,12 +13,12 @@ php:
     - 7.3
 
 before_install:
-    - composer require php-coveralls/php-coveralls
+    - composer require php-coveralls/php-coveralls --no-interaction --no-progress
     - composer global require localheinz/composer-normalize --no-interaction --prefer-dist --no-progress
-    - composer self-update --stable
+    - composer self-update --stable --no-interaction --no-progress
 
 install:
-    - composer install
+    - composer install --no-interaction --prefer-dist --no-progress
 
 script:
     - mkdir -p build/logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 Changelog for 6.0
 =================
 
-*   Added new form option `row_attr`, that acts like `attr` but is dedicated for form row attributes.
+*   Added new form option `attr_row`, that acts like `attr` but is dedicated for form row attributes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,4 @@
 Changelog for 6.0
 =================
+
+*   Added new form option `row_attr`, that acts like `attr` but is dedicated for form row attributes.

--- a/src/Form/Extension/FormRowAttributesExtension.php
+++ b/src/Form/Extension/FormRowAttributesExtension.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\RadBundle\Form\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Adds a new form option "row_attr", that acts like "attr" but is rendered as
+ * attributes on the form row and not the form widget.
+ */
+class FormRowAttributesExtension extends AbstractTypeExtension
+{
+    /**
+     * @inheritDoc
+     */
+    public function buildForm (FormBuilderInterface $builder, array $options)
+    {
+        $builder->setAttribute("row_attr", $options["row_attr"]);
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function buildView (FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars["row_attr"] = $form->getConfig()->getAttribute("row_attr");
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function configureOptions (OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefined(["row_attr"])
+            ->setAllowedTypes("row_attr", "array")
+            ->setDefaults([
+                "row_attr" => [],
+            ]);
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public static function getExtendedTypes () : array
+    {
+        return [
+            FormType::class,
+        ];
+    }
+}

--- a/src/Form/Extension/FormRowAttributesExtension.php
+++ b/src/Form/Extension/FormRowAttributesExtension.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * Adds a new form option "row_attr", that acts like "attr" but is rendered as
+ * Adds a new form option "attr_row", that acts like "attr" but is rendered as
  * attributes on the form row and not the form widget.
  */
 class FormRowAttributesExtension extends AbstractTypeExtension
@@ -20,7 +20,7 @@ class FormRowAttributesExtension extends AbstractTypeExtension
      */
     public function buildForm (FormBuilderInterface $builder, array $options)
     {
-        $builder->setAttribute("row_attr", $options["row_attr"]);
+        $builder->setAttribute("attr_row", $options["attr_row"]);
     }
 
 
@@ -29,7 +29,7 @@ class FormRowAttributesExtension extends AbstractTypeExtension
      */
     public function buildView (FormView $view, FormInterface $form, array $options)
     {
-        $view->vars["row_attr"] = $form->getConfig()->getAttribute("row_attr");
+        $view->vars["attr_row"] = $form->getConfig()->getAttribute("attr_row");
     }
 
 
@@ -39,10 +39,10 @@ class FormRowAttributesExtension extends AbstractTypeExtension
     public function configureOptions (OptionsResolver $resolver)
     {
         $resolver
-            ->setDefined(["row_attr"])
-            ->setAllowedTypes("row_attr", "array")
+            ->setDefined(["attr_row"])
+            ->setAllowedTypes("attr_row", "array")
             ->setDefaults([
-                "row_attr" => [],
+                "attr_row" => [],
             ]);
     }
 

--- a/src/Form/Extension/FormRowAttributesExtension.php
+++ b/src/Form/Extension/FormRowAttributesExtension.php
@@ -18,7 +18,7 @@ class FormRowAttributesExtension extends AbstractTypeExtension
     /**
      * @inheritDoc
      */
-    public function buildForm (FormBuilderInterface $builder, array $options)
+    public function buildForm (FormBuilderInterface $builder, array $options) : void
     {
         $builder->setAttribute("attr_row", $options["attr_row"]);
     }
@@ -27,7 +27,7 @@ class FormRowAttributesExtension extends AbstractTypeExtension
     /**
      * @inheritDoc
      */
-    public function buildView (FormView $view, FormInterface $form, array $options)
+    public function buildView (FormView $view, FormInterface $form, array $options) : void
     {
         $view->vars["attr_row"] = $form->getConfig()->getAttribute("attr_row");
     }
@@ -36,7 +36,7 @@ class FormRowAttributesExtension extends AbstractTypeExtension
     /**
      * @inheritDoc
      */
-    public function configureOptions (OptionsResolver $resolver)
+    public function configureOptions (OptionsResolver $resolver) : void
     {
         $resolver
             ->setDefined(["attr_row"])

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -3,5 +3,6 @@ services:
         autoconfigure: true
         autowire: true
 
-    Becklyn\RadBundle\Form\FormErrorMapper: ~
-    Becklyn\RadBundle\Twig\RadTwigExtension: ~
+    Becklyn\RadBundle\:
+        resource: ../../*
+        exclude: ../../{Entity,Exception,Pagination,Resources,BecklynRadBundle.php}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| Improvement?  | no <!-- improves an existing feature, not adding a new one --> 
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
| Docs PR       | 😞 

<!-- describe your changes below -->
Adds a new form option called `attr_row`, that is basically mirrored from `attr`, but is supposed to set attributes on the `<div>` wrapping the form row, instead on the form widget.