### PR TITLE
Add `classnames` twig function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@ Changelog for 6.0
 *   Added `LabeledEntityRemovalBlockedException`
 *   Added `Model`
 *   Bumped all dependencies. PHP 7.2+ and Symfony 4.2+ are now required.
+*   Added `classnames()` twig function.

--- a/src/Twig/RadTwigExtension.php
+++ b/src/Twig/RadTwigExtension.php
@@ -4,6 +4,7 @@ namespace Becklyn\RadBundle\Twig;
 
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 class RadTwigExtension extends AbstractExtension
 {
@@ -23,7 +24,44 @@ class RadTwigExtension extends AbstractExtension
 
 
     /**
-     * @return array|\Twig_Filter[]
+     * @param array $classes
+     *
+     * @return string
+     */
+    public function formatClassNames (array $classes)
+    {
+        $result = [];
+
+        foreach ($classes as $class => $enabled)
+        {
+            // support key less values
+            if (\is_int($class))
+            {
+                $result[] = $enabled;
+            }
+            elseif ($enabled)
+            {
+                $result[] = $class;
+            }
+        }
+
+        return \implode(" ", $result);
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getFunctions () : array
+    {
+        return [
+            new TwigFunction("classnames", [$this, "formatClassNames"]),
+        ];
+    }
+
+
+    /**
+     * @inheritDoc
      */
     public function getFilters () : array
     {

--- a/src/Twig/RadTwigExtension.php
+++ b/src/Twig/RadTwigExtension.php
@@ -28,7 +28,7 @@ class RadTwigExtension extends AbstractExtension
      *
      * @return string
      */
-    public function formatClassNames (array $classes)
+    public function formatClassNames (array $classes) : string
     {
         $result = [];
 

--- a/tests/Twig/RadTwigExtensionTest.php
+++ b/tests/Twig/RadTwigExtensionTest.php
@@ -17,4 +17,47 @@ class RadTwigExtensionTest extends TestCase
         self::assertSame("abc 123", $extension->appendToKey($array, "existing", "123")["existing"]);
         self::assertSame("123", $extension->appendToKey($array, "missing", "123")["missing"]);
     }
+
+
+    /**
+     * @return array
+     */
+    public function provideClassnames () : array
+    {
+        return [
+            "simple" => [
+                ["a" => true, "b" => true],
+                "a b",
+            ],
+            "numbers" => [
+                ["zero" => 0, "one" => 1, "two" => 2],
+                "one two",
+            ],
+            "bool" => [
+                ["true" => true, "false" => false, "null" => null],
+                "true",
+            ],
+            "empty" => [
+                [],
+                "",
+            ],
+            "keyless values" => [
+                ["a" => true, "b", "c" => false, "d", "e" => true],
+                "a b d e",
+            ],
+        ];
+    }
+
+
+    /**
+     * @dataProvider provideClassnames
+     *
+     * @param array  $classnames
+     * @param string $expected
+     */
+    public function testClassnames (array $classnames, string $expected) : void
+    {
+        $extension = new RadTwigExtension();
+        self::assertSame($extension->formatClassNames($classnames), $expected);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| Improvement?  | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
| Docs PR       | —

<!-- describe your changes below -->
Ported the `classnames()` to twig